### PR TITLE
Enable using n8n in subpath and few other improvements

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -1,14 +1,5 @@
 # Folder where data should be saved
-DATA_FOLDER=__DATADIR__
-
-# The top level domain to serve from
-DOMAIN_NAME=__DOMAIN__
-
-# The subdomain to serve from
-SUBDOMAIN=__PATH__
-
-# DOMAIN_NAME and SUBDOMAIN combined decide where n8n will be reachable from
-# above example would result in: https://n8n.example.com
+N8N_USER_FOLDER=__DATADIR__
 
 # Authentication - IMPORTANT ALWAYS CHANGE!
 N8N_BASIC_AUTH_ACTIVE=true

--- a/conf/.env
+++ b/conf/.env
@@ -22,8 +22,9 @@ N8N_PATH=__PATH__/
 # If not set New York time will be used
 GENERIC_TIMEZONE=__TIMEZONE__
 
-# The email address to use for the SSL certificate creation
-SSL_EMAIL=user@example.com
+# Use http (we're behind a reverse-proxy)
+N8N_PROTOCOL=http
+N8N_LISTEN_ADDRESS=127.0.0.1
 
 DB_MYSQLDB_DATABASE=__DB_NAME__
 DB_MYSQLDB_HOST_FILE=localhost

--- a/conf/.env
+++ b/conf/.env
@@ -15,6 +15,9 @@ N8N_BASIC_AUTH_ACTIVE=true
 N8N_BASIC_AUTH_USER=__ADMIN__
 N8N_BASIC_AUTH_PASSWORD=__PASSWORD__
 
+# The path n8n is deployed to.
+N8N_PATH=__PATH__/
+
 # Optional timezone to set which gets used by Cron-Node by default
 # If not set New York time will be used
 GENERIC_TIMEZONE=__TIMEZONE__

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,4 +1,5 @@
-location / {
+#sub_path_only rewrite ^__PATH__$ __PATH__/ permanent;
+location __PATH__/ {
 
   # Force usage of https
   if ($scheme = http) {
@@ -13,9 +14,9 @@ location / {
   proxy_set_header X-Real-IP $remote_addr;
   proxy_set_header X-Forwarded-For $remote_addr;
   proxy_set_header X-Forwarded-Proto $scheme;
-  proxy_set_header Host $host; 
+  proxy_set_header Host $host;
   proxy_http_version 1.1;
-  
+
   # WebSocket proxying - from http://nginx.org/en/docs/http/websocket.html
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection $connection_upgrade;

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,16 @@
                 "type": "domain"
             },
             {
+                "name": "path",
+                "type": "path",
+                "ask": {
+                    "en": "Choose a path for n8n",
+                    "fr": "Choisissez un chemin pour n8n"
+                },
+                "example": "/n8n",
+                "default": "/n8n"
+            },
+            {
                 "name": "admin",
                 "type": "user"
             },

--- a/scripts/backup
+++ b/scripts/backup
@@ -67,4 +67,4 @@ ynh_mysql_dump_db --database="$db_name" > db.sql
 # END OF SCRIPT
 #=================================================
 
-ynh_print_info --message="Backup script completed for Etherpad. (YunoHost will then actually copy those files to the archive)."
+ynh_print_info --message="Backup script completed for n8n. (YunoHost will then actually copy those files to the archive)."

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -17,7 +17,7 @@ old_domain=$YNH_APP_OLD_DOMAIN
 old_path=$YNH_APP_OLD_PATH
 
 new_domain=$YNH_APP_NEW_DOMAIN
-new_path="/"
+new_path=$YNH_APP_NEW_PATH
 
 app=$YNH_APP_INSTANCE_NAME
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -32,6 +32,7 @@ port=$(ynh_app_setting_get --app=$app --key=port)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 db_pwd=$(ynh_app_setting_get --app=$app --key=mysqlpwd)
 datadir=$(ynh_app_setting_get --app=$app --key=datadir)
+admin=$(ynh_app_setting_get --app=$app --key=admin)
 password=$(ynh_app_setting_get --app=$app --key=password)
 timezone="$(cat /etc/timezone)"
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -41,7 +41,7 @@ timezone="$(cat /etc/timezone)"
 #=================================================
 ynh_script_progression --message="Backing up $app before changing its URL (may take a while)..." --weight=2
 
-# Backup the current version of Etherpad
+# Backup the current version of n8n
 ynh_backup_before_upgrade
 ynh_clean_setup () {
 	# Remove the new domain config file, the remove script won't do it as it doesn't know yet its location.

--- a/scripts/install
+++ b/scripts/install
@@ -24,7 +24,7 @@ ynh_abort_if_errors
 #=================================================
 
 domain=$YNH_APP_ARG_DOMAIN
-path_url="/"
+path_url=$YNH_APP_ARG_PATH
 is_public=$YNH_APP_ARG_IS_PUBLIC
 password=$YNH_APP_ARG_PASSWORD
 admin=$YNH_APP_ARG_ADMIN

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -21,7 +21,11 @@ path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 port=$(ynh_app_setting_get --app=$app --key=port)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)
+db_pwd=$(ynh_app_setting_get --app=$app --key=mysqlpwd)
 datadir=$(ynh_app_setting_get --app=$app --key=datadir)
+admin=$(ynh_app_setting_get --app=$app --key=admin)
+password=$(ynh_app_setting_get --app=$app --key=password)
+timezone="$(cat /etc/timezone)"
 
 #=================================================
 # CHECK VERSION
@@ -93,6 +97,16 @@ ynh_add_nginx_config
 ynh_script_progression --message="Installing dependencies..." --weight=12
 
 ynh_install_nodejs --nodejs_version=$nodejs_version
+
+#=================================================
+# UPGRADE A CONFIGURATION FILE
+#=================================================
+ynh_script_progression --message="Upgrade a configuration file..." --weight=1
+
+ynh_add_config --template="../conf/.env" --destination="$final_path/.env"
+
+chmod 400 "$final_path/.env"
+chown $app:$app "$final_path/.env"
 
 #=================================================
 # SETUP SYSTEMD


### PR DESCRIPTION
## Problem

- I would like to install n8n in a subpath instead of a full-domain;
- Also don't enable https in n8n runtime (useless because of nginx);
- Remove useless (?) variables;
- Upgrading the app doesn't update the `.env` file;

## Solution

- Change `.env` for letting n8n point to the right endpoint
- Adapt the change_url script;
- Adapt the upgrade script to apply again the template for `.env`;

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
