### PR TITLE
Add autoupdate strategy

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -53,6 +53,13 @@ ram.runtime = "50M"
 
     [resources.ports]
 
+    [resources.sources]
+    
+        [resources.sources.main]
+        url = "https://github.com/n8n-io/n8n/archive/refs/tags/n8n@1.9.3.zip"
+        sha256 = "53114a7817f319bfc065566cd77ae889aacb2f2ffd8283f905292a31e19d41e1"
+        autoupdate.strategy = "latest_github_release"
+
     [resources.system_user]
     allow_email = true
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -54,11 +54,15 @@ ram.runtime = "50M"
     [resources.ports]
 
     [resources.sources]
-    
+
+        # Source is only added for autoupdate, it's not actually being downloaded
+        # For updating version n8n version needs to be updated in `_common.sh`
         [resources.sources.main]
         url = "https://github.com/n8n-io/n8n/archive/refs/tags/n8n@1.9.3.zip"
         sha256 = "53114a7817f319bfc065566cd77ae889aacb2f2ffd8283f905292a31e19d41e1"
         autoupdate.strategy = "latest_github_release"
+        autoupdate.version_regex = "^n8n@(.*)$"
+        prefetch = false
 
     [resources.system_user]
     allow_email = true


### PR DESCRIPTION
## Problem

There is no autoupdate strategy defined.

## Solution

Add source and latest_github_release strategy to `manifest.toml`. Note, that this autoupdate strategy won't be fully automized as the n8n version still needs to be manually adopted in `_common.sh`.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
