### PR TITLE
Bump to version 1.29 of n8n

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "n8n"
 description.en = "Workflow Automation Tool. Easily automate tasks across different services"
 description.fr = "Outil d'automatisation du flux de travail. Automatisez facilement les tâches sur différents services"
 
-version = "1.9.3~ynh1"
+version = "1.29.0~ynh1"
 
 maintainers = []
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 nodejs_version=20
 
-n8n_version=1.9.3
+n8n_version=1.29.0
 
 timezone="$(cat /etc/timezone)"
 main_domain=$(cat /etc/yunohost/current_host)


### PR DESCRIPTION
## Problem

- The available version is 14 releases behind

## Solution

- Bump version to the latest stable

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
