### PR TITLE
Change license from Apache-2.0 to SUL-1.0

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -10,7 +10,7 @@ version = "2.18.5~ynh1"
 maintainers = []
 
 [upstream]
-license = "Apache-2.0"
+license = "SUL-1.0"
 website = "https://n8n.io/"
 admindoc = "https://docs.n8n.io/"
 code = "https://github.com/n8n-io/n8n"


### PR DESCRIPTION
## Problem

Upstream license is wrong

## Solution

Change license to SUL-1.0.
Source: https://github.com/n8n-io/n8n/blob/master/LICENSE.md
SPDX: https://spdx.org/licenses/SUL-1.0.html

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
